### PR TITLE
Fix #12 and related issues.

### DIFF
--- a/apps/Browser/BrowserTab.js
+++ b/apps/Browser/BrowserTab.js
@@ -6,7 +6,7 @@ const $ = require("jquery");
 const template = fs.readFileSync(`${__dirname}/templates/tab-template.html`, "utf8");
 const barTemplate = fs.readFileSync(`${__dirname}/templates/bar-tab-template.html`, "utf8");
 
-const urlRegex = /[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.([a-z]{2,4})\b(?:\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?[-a-zA-Z0-9@:%_+.~#?&//=]*/gi;
+const urlRegex = /[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.([a-zA-Z\d]{2,63})\b(?:\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?[-a-zA-Z0-9@:%_+.~#?&//=]*/gi;
 
 class BrowserTab {
     constructor(window, options) {
@@ -76,6 +76,11 @@ class BrowserTab {
     loadURL(url) {
         const webview = this.webview[0];
         const validURL = new RegExp(urlRegex).exec(url);
+
+        console.log(url);
+        console.log(urlRegex);
+
+        console.log(validURL);
 
         if (validURL && this.tlds.indexOf(validURL[1].toUpperCase()) !== -1) {
             if (!/^https?:\/\//.test(url)) {

--- a/apps/Browser/BrowserTab.js
+++ b/apps/Browser/BrowserTab.js
@@ -6,7 +6,7 @@ const $ = require("jquery");
 const template = fs.readFileSync(`${__dirname}/templates/tab-template.html`, "utf8");
 const barTemplate = fs.readFileSync(`${__dirname}/templates/bar-tab-template.html`, "utf8");
 
-const urlRegex = /[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.([a-zA-Z\d]{2,63})\b(?:\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?[-a-zA-Z0-9@:%_+.~#?&//=]*/gi;
+const urlRegex = /[-a-zA-Z0-9@:%_+.~#?&//=]{2,256}\.([a-zA-Z\d-]{2,63})\b(?:\/[-a-zA-Z0-9@:%_+.~#?&//=]*)?[-a-zA-Z0-9@:%_+.~#?&//=]*/gi;
 
 class BrowserTab {
     constructor(window, options) {

--- a/apps/Browser/index.js
+++ b/apps/Browser/index.js
@@ -8,7 +8,7 @@ const tldsFilepath = `${__dirname}/tlds.txt`;
 // Get an array of all tlds
 const tldsRaw = fs.readFileSync(tldsFilepath, "utf8");
 // Splits the TLDS, removes last empty line, and removes char 13 at end of each entry
-const tlds = tldsRaw.split("\n").slice(0, -1).map(v => v.slice(0, -1));
+const tlds = tldsRaw.split("\n").slice(0, -1).map(v => v.trim());
 
 // Move this to some settings file somewhere
 const defaultPage = "https://www.google.com/"; // eslint-disable-line no-unused-vars


### PR DESCRIPTION
This fixes domains not being properly matched due to:
1) Difference in newlines between Unix and DOS-based operating systems.
2) 4-character match for TLDs instead of the 63 character standard.